### PR TITLE
Add CodeCov integration to github actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,3 +12,6 @@ jobs:
             node-version: 20
         - run: npm install
         - run: npm run test:cov
+        - uses: codecov/codecov-action@v3
+          env:
+            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Why:
Closes #12 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
We should now see coverage reports uploaded to CodeCov