### PR TITLE
Enforce project and patch line coverage on PRs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
         "esbenp.prettier-vscode",
         "GitHub.vscode-github-actions",
         "GitHub.copilot",
-        "GitHub.copilot-chat"
+        "GitHub.copilot-chat",
+        "codecov.codecov"
       ]
     }
   }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 5%
+        paths: 
+          - "src"
+    patch:
+      default:
+        target: 100%
+        threshold: 20%
+        paths:
+          - "src"


### PR DESCRIPTION
### Why:
Closes #22 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Pull requests will now be rejected if project coverage drops below 95%, or patch coverage (modified lines) is below 80%.