### PR TITLE
Run E2E tests automatically on pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
-name: Unit Tests
+name: Tests
 
 on: [pull_request]
 
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -15,3 +15,12 @@ jobs:
         - uses: codecov/codecov-action@v3
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cypress-io/github-action@v6
+        with:
+          build: npm run build
+          start: npm run start


### PR DESCRIPTION
### Why:
Closes #30 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
- E2E tests should now run automatically on pull request.
- 'build' step is now 'unit-tests'
- We can add a promotion blocker to E2E tests now