### PR TITLE
Ynab api integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "ynab-analyzer-frontend-react",
       "version": "0.1.0",
       "dependencies": {
-        "@boiseitguru/cookie-cutter": "^0.2.1",
-        "@radix-ui/react-slot": "^1.0.2",
+        "@boiseitguru/cookie-cutter": "latest",
+        "@radix-ui/react-slot": "latest",
         "class-variance-authority": "latest",
         "clsx": "latest",
         "lucide-react": "latest",

--- a/src/__tests__/lib/ynab-api/call-with-token.test.ts
+++ b/src/__tests__/lib/ynab-api/call-with-token.test.ts
@@ -1,0 +1,55 @@
+import { callWithToken } from '@/lib/ynab-api/call-with-token';
+
+const getCookieMock = jest.fn((tokenName: string) => {
+  return {
+    value: tokenName,
+  };
+});
+
+jest.mock('next/headers', () => {
+  return {
+    cookies: jest.fn(() => {
+      return {
+        get: getCookieMock,
+      };
+    }),
+  };
+});
+
+describe('callWithToken', () => {
+  const mockResponse = { data: {} };
+  const mockJsonPromise = Promise.resolve(mockResponse);
+  const mockFetchPromise = Promise.resolve({
+    json: () => mockJsonPromise,
+  });
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+  });
+
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  it('should call the API with the correct endpoint and headers', async () => {
+    const expectedEndpoint = 'test';
+    const expectedHeaders = {
+      Authorization: `Bearer ynabToken`,
+    };
+
+    await callWithToken(expectedEndpoint);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.youneedabudget.com/v1/${expectedEndpoint}`,
+      {
+        headers: new Headers(expectedHeaders),
+      }
+    );
+  });
+
+  it('should return the data from the API', async () => {
+    const result = await callWithToken('test');
+
+    expect(result).toEqual(mockResponse);
+  });
+});

--- a/src/__tests__/lib/ynab-api/get-budgets.test.ts
+++ b/src/__tests__/lib/ynab-api/get-budgets.test.ts
@@ -1,0 +1,55 @@
+import { getBudgets } from '@/lib/ynab-api/get-budgets';
+
+const getCookieMock = jest.fn((tokenName: string) => {
+  return {
+    value: tokenName,
+  };
+});
+
+jest.mock('next/headers', () => {
+  return {
+    cookies: jest.fn(() => {
+      return {
+        get: getCookieMock,
+      };
+    }),
+  };
+});
+
+describe('getBudgets', () => {
+  const mockResponse = { data: {} };
+  const mockJsonPromise = Promise.resolve(mockResponse);
+  const mockFetchPromise = Promise.resolve({
+    json: () => mockJsonPromise,
+  });
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+  });
+
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  it('should call the YNAB API with the correct endpoint and headers', async () => {
+    const expectedEndpoint = 'budgets';
+    const expectedHeaders = {
+      Authorization: `Bearer ynabToken`,
+    };
+
+    await getBudgets();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.youneedabudget.com/v1/${expectedEndpoint}`,
+      {
+        headers: new Headers(expectedHeaders),
+      }
+    );
+  });
+
+  it('should return the data from the YNAB API', async () => {
+    const result = await getBudgets();
+
+    expect(result).toEqual(mockResponse);
+  });
+});

--- a/src/lib/ynab-api/call-with-token.ts
+++ b/src/lib/ynab-api/call-with-token.ts
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers';
+
+export async function callWithToken(endpoint: string) {
+  const cookieStore = cookies();
+  const headers = {
+    Authorization: `Bearer ${cookieStore.get('ynabToken')?.value}`,
+  };
+  return fetch(`https://api.youneedabudget.com/v1/${endpoint}`, {
+    headers: new Headers(headers),
+  })
+    .then((res: Response) => {
+      return res.json();
+    })
+    .then((data) => {
+      return data;
+    });
+}

--- a/src/lib/ynab-api/get-budgets.ts
+++ b/src/lib/ynab-api/get-budgets.ts
@@ -1,0 +1,7 @@
+import { callWithToken } from '@/lib/ynab-api/call-with-token';
+
+export function getBudgets() {
+  const endpoint = 'budgets';
+
+  return callWithToken(endpoint);
+}


### PR DESCRIPTION
### Why:
Closes #39 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Added YNAB API request skeleton and working example for `get/budgets`.
Still need to add advanced error handling and typing to responses.