### PR TITLE
Add inline code coverage to vscode dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
         "GitHub.copilot",
         "GitHub.copilot-chat",
         "codecov.codecov",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "ryanluker.vscode-coverage-gutters"
       ]
     }
   }


### PR DESCRIPTION
### Why:
Closes #49 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Added extension to provide inline code coverage in vscode