### PR TITLE
Miscellaneous unit test clean up

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   moduleDirectories: ['node_modules', 'src'],
   collectCoverageFrom: ['**/*.{ts,tsx}', '!**/index.ts'],
+  coveragePathIgnorePatterns: ['lib/tests'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,18 @@
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+const getCookieMock = jest.fn((tokenName) => {
+  return {
+    value: tokenName,
+  };
+});
+
+jest.mock('next/headers', () => {
+  return {
+    cookies: jest.fn(() => {
+      return {
+        get: getCookieMock,
+      };
+    }),
+  };
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The base URL for the You Need A Budget (YNAB) API.
+ */
+export const ynabApiBaseUrl = 'https://api.youneedabudget.com/v1';

--- a/src/lib/tests/test-helpers.ts
+++ b/src/lib/tests/test-helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * Mocks the global `fetch` function to return a mock response.
+ * @param mockResponse - The mock response to be returned by the `fetch` function.
+ */
+export function mockFetch(mockResponse: any) {
+  const mockJsonPromise = Promise.resolve(mockResponse);
+  const mockFetchPromise = Promise.resolve({
+    json: () => mockJsonPromise,
+  });
+  global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+}

--- a/src/lib/ynab-api/call-with-token.test.ts
+++ b/src/lib/ynab-api/call-with-token.test.ts
@@ -1,30 +1,12 @@
 import { callWithToken } from '@/lib/ynab-api/call-with-token';
-
-const getCookieMock = jest.fn((tokenName: string) => {
-  return {
-    value: tokenName,
-  };
-});
-
-jest.mock('next/headers', () => {
-  return {
-    cookies: jest.fn(() => {
-      return {
-        get: getCookieMock,
-      };
-    }),
-  };
-});
+import { mockFetch } from '@/lib/tests/test-helpers';
+import { ynabApiBaseUrl } from '@/lib/constants';
 
 describe('callWithToken', () => {
-  const mockResponse = { data: {} };
-  const mockJsonPromise = Promise.resolve(mockResponse);
-  const mockFetchPromise = Promise.resolve({
-    json: () => mockJsonPromise,
-  });
+  const mockResponse = { data: { result: 123 } };
 
   beforeEach(() => {
-    global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+    mockFetch(mockResponse);
   });
 
   afterEach(() => {
@@ -40,7 +22,7 @@ describe('callWithToken', () => {
     await callWithToken(expectedEndpoint);
 
     expect(global.fetch).toHaveBeenCalledWith(
-      `https://api.youneedabudget.com/v1/${expectedEndpoint}`,
+      `${ynabApiBaseUrl}/${expectedEndpoint}`,
       {
         headers: new Headers(expectedHeaders),
       }

--- a/src/lib/ynab-api/call-with-token.ts
+++ b/src/lib/ynab-api/call-with-token.ts
@@ -1,11 +1,12 @@
 import { cookies } from 'next/headers';
+import { ynabApiBaseUrl } from '@/lib/constants';
 
 export async function callWithToken(endpoint: string) {
   const cookieStore = cookies();
   const headers = {
     Authorization: `Bearer ${cookieStore.get('ynabToken')?.value}`,
   };
-  return fetch(`https://api.youneedabudget.com/v1/${endpoint}`, {
+  return fetch(`${ynabApiBaseUrl}/${endpoint}`, {
     headers: new Headers(headers),
   })
     .then((res: Response) => {

--- a/src/lib/ynab-api/get-budgets.test.ts
+++ b/src/lib/ynab-api/get-budgets.test.ts
@@ -1,30 +1,12 @@
 import { getBudgets } from '@/lib/ynab-api/get-budgets';
-
-const getCookieMock = jest.fn((tokenName: string) => {
-  return {
-    value: tokenName,
-  };
-});
-
-jest.mock('next/headers', () => {
-  return {
-    cookies: jest.fn(() => {
-      return {
-        get: getCookieMock,
-      };
-    }),
-  };
-});
+import { mockFetch } from '@/lib/tests/test-helpers';
+import { ynabApiBaseUrl } from '@/lib/constants';
 
 describe('getBudgets', () => {
-  const mockResponse = { data: {} };
-  const mockJsonPromise = Promise.resolve(mockResponse);
-  const mockFetchPromise = Promise.resolve({
-    json: () => mockJsonPromise,
-  });
+  const mockResponse = { data: { result: 123 } };
 
   beforeEach(() => {
-    global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+    mockFetch(mockResponse);
   });
 
   afterEach(() => {
@@ -40,7 +22,7 @@ describe('getBudgets', () => {
     await getBudgets();
 
     expect(global.fetch).toHaveBeenCalledWith(
-      `https://api.youneedabudget.com/v1/${expectedEndpoint}`,
+      `${ynabApiBaseUrl}/${expectedEndpoint}`,
       {
         headers: new Headers(expectedHeaders),
       }


### PR DESCRIPTION
### Why:
Closes #47 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
We now have a `test-helpers` file for duplicated unit test code, and an example of utilizing `jest.setup.ts` for universal test setup (in this case, cookie mocks).